### PR TITLE
[FEAT] 맛집 정보 조회 API 구현

### DIFF
--- a/api-server/src/main/java/com/pickmylunch/api/ApiServerApplication.java
+++ b/api-server/src/main/java/com/pickmylunch/api/ApiServerApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = {
 		"com.pickmylunch.common",

--- a/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberController.java
@@ -29,7 +29,7 @@ public class MemberController {
     }
 
     @GetMapping("/exists/email")
-    public ResponseEntity<Boolean> checkDuplicateEmail(@RequestParam String email) {
+    public ResponseEntity<Boolean> checkDuplicateEmail(@RequestParam("email") String email) {
         return ResponseEntity.ok(memberService.isEmailExist(email));
     }
 

--- a/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberController.java
@@ -24,7 +24,7 @@ public class MemberController {
     }
 
     @GetMapping("/exists/member-name")
-    public ResponseEntity<Boolean> checkDuplicateMemberName(@RequestParam("memberName") String memberName) {
+    public ResponseEntity<Boolean> checkDuplicateMemberName(@RequestParam("member-name") String memberName) {
         return ResponseEntity.ok(memberService.isMemberNameExist(memberName));
     }
 

--- a/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberLocationController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/member/controller/MemberLocationController.java
@@ -46,8 +46,8 @@ public class MemberLocationController {
     }
 
     @PatchMapping("/static/{locationId}/change-default")
-    public ResponseEntity<Void> changeDefaultStaticLocation(@PathVariable Long locationId, @AuthenticationPrincipal AuthUser authUser) {
-        memberLocationService.changeDefaultStaticLocation(locationId, authUser.getId());
+    public ResponseEntity<Void> changeDefaultStaticLocation(@PathVariable Long locationId, @AuthenticationPrincipal AuthUser authUser, @RequestParam("is-default") boolean isDefault) {
+        memberLocationService.changeDefaultStaticLocation(locationId, authUser.getId(), isDefault);
         return ResponseEntity.ok().build();
     }
 

--- a/api-server/src/main/java/com/pickmylunch/api/domain/member/service/MemberLocationService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/member/service/MemberLocationService.java
@@ -52,10 +52,10 @@ public class MemberLocationService {
         return StaticLocationResponseDto.of(defaultLocation);
     }
 
-    public void changeDefaultStaticLocation(Long locationId, Long memberId) {
-        resetMemberDefaultLocation(memberId);
+    public void changeDefaultStaticLocation(Long locationId, Long memberId, boolean isDefault) {
         MemberLocation locationToBeDefault = findByIdAndMemberId(locationId, memberId);
-        locationToBeDefault.changeIsDefault(true);
+        if (isDefault) resetMemberDefaultLocation(memberId);
+        locationToBeDefault.changeIsDefault(isDefault);
         memberLocationRepository.save(locationToBeDefault);
     }
 

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/NearbyRestaurantController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/NearbyRestaurantController.java
@@ -1,0 +1,29 @@
+package com.pickmylunch.api.domain.restaurant.controller;
+
+import com.pickmylunch.api.domain.restaurant.service.LocationService;
+import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/restaurants/nearby")
+public class NearbyRestaurantController {
+
+    private final LocationService locationService;
+
+    @GetMapping
+    public ResponseEntity<Page<RestaurantResponseDto>> findRestaurantsWithinRange(
+            @RequestParam double lat,
+            @RequestParam double lon,
+            @RequestParam(defaultValue = "1") double range,
+            @RequestParam(defaultValue = "distance") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<RestaurantResponseDto> result = locationService.getRestaurantsWithinRange(lat, lon, range, sort, page, size);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
@@ -20,8 +20,13 @@ public class RestaurantController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<Page<RestaurantResponseDto>> getRestaurantsBySigungu(Pageable pageable, @RequestParam(required = false) String sigungu) {
-        return ResponseEntity.ok(restaurantService.getRestaurantsBySigungu(pageable, sigungu));
+    public ResponseEntity<Page<RestaurantResponseDto>> getRestaurantsBySigungu(
+            Pageable pageable,
+            @RequestParam(required = false) String sigungu,
+            @RequestParam(defaultValue = "viewCount") String sort,
+            @RequestParam(defaultValue = "false") boolean ascending) {
+
+        return ResponseEntity.ok(restaurantService.getRestaurantsBySigungu(pageable, sigungu, sort, ascending));
     }
 
     @GetMapping("/{id}")

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
@@ -1,13 +1,16 @@
 package com.pickmylunch.api.domain.restaurant.controller;
 
+import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantDetailResponseDto;
 import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
 import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
 import com.pickmylunch.api.domain.restaurant.service.RestaurantService;
+import com.pickmylunch.common.entity.Restaurant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +26,10 @@ public class RestaurantController {
     @GetMapping
     public ResponseEntity<Page<RestaurantResponseDto>> getAllRestaurant(Pageable pageable) {
         return ResponseEntity.ok(restaurantService.getAllRestaurants(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RestaurantDetailResponseDto> getRestaurantById(@PathVariable String id) {
+        return ResponseEntity.ok(restaurantService.getRestaurantById(id));
     }
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
@@ -1,20 +1,11 @@
 package com.pickmylunch.api.domain.restaurant.controller;
 
-import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantDetailResponseDto;
-import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
-import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
-import com.pickmylunch.api.domain.restaurant.service.RestaurantService;
-import com.pickmylunch.common.entity.Restaurant;
+import com.pickmylunch.api.domain.restaurant.dto.response.*;
+import com.pickmylunch.api.domain.restaurant.service.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +17,11 @@ public class RestaurantController {
     @GetMapping
     public ResponseEntity<Page<RestaurantResponseDto>> getAllRestaurant(Pageable pageable) {
         return ResponseEntity.ok(restaurantService.getAllRestaurants(pageable));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<RestaurantResponseDto>> getRestaurantsBySigungu(Pageable pageable, @RequestParam(required = false) String sigungu) {
+        return ResponseEntity.ok(restaurantService.getRestaurantsBySigungu(pageable, sigungu));
     }
 
     @GetMapping("/{id}")

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/controller/RestaurantController.java
@@ -1,0 +1,27 @@
+package com.pickmylunch.api.domain.restaurant.controller;
+
+import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
+import com.pickmylunch.api.domain.restaurant.service.RestaurantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/restaurant")
+public class RestaurantController {
+
+    private final RestaurantService restaurantService;
+
+    @GetMapping
+    public ResponseEntity<Page<RestaurantResponseDto>> getAllRestaurant(Pageable pageable) {
+        return ResponseEntity.ok(restaurantService.getAllRestaurants(pageable));
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantDetailResponseDto.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantDetailResponseDto.java
@@ -1,0 +1,35 @@
+package com.pickmylunch.api.domain.restaurant.dto.response;
+
+import com.pickmylunch.common.entity.Restaurant;
+import com.pickmylunch.common.entity.enums.Category;
+import org.locationtech.jts.geom.Point;
+
+public record RestaurantDetailResponseDto(
+        String id,
+        String restaurantName,
+        String restaurantTel,
+        String dosi,
+        Category category,
+        String sigungu,
+        String jibunDetailAddress,
+        String doroDetailAddress,
+        Point location,
+        double ratingAverage,
+        long totalViewCount
+) {
+    public static RestaurantDetailResponseDto of(Restaurant restaurant) {
+        return new RestaurantDetailResponseDto(
+                restaurant.getId(),
+                restaurant.getRestaurantName(),
+                restaurant.getRestaurantTel(),
+                restaurant.getDosi(),
+                restaurant.getCategory(),
+                restaurant.getSigungu(),
+                restaurant.getJibunDetailAddress(),
+                restaurant.getDoroDetailAddress(),
+                restaurant.getLocation(),
+                restaurant.getRatingAverage(),
+                restaurant.getTotalViewCount()
+        );
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantDetailResponseDto.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantDetailResponseDto.java
@@ -2,7 +2,6 @@ package com.pickmylunch.api.domain.restaurant.dto.response;
 
 import com.pickmylunch.common.entity.Restaurant;
 import com.pickmylunch.common.entity.enums.Category;
-import org.locationtech.jts.geom.Point;
 
 public record RestaurantDetailResponseDto(
         String id,
@@ -13,7 +12,8 @@ public record RestaurantDetailResponseDto(
         String sigungu,
         String jibunDetailAddress,
         String doroDetailAddress,
-        Point location,
+        double lon,
+        double lat,
         double ratingAverage,
         long totalViewCount
 ) {
@@ -27,7 +27,8 @@ public record RestaurantDetailResponseDto(
                 restaurant.getSigungu(),
                 restaurant.getJibunDetailAddress(),
                 restaurant.getDoroDetailAddress(),
-                restaurant.getLocation(),
+                restaurant.getLocation().getX(),
+                restaurant.getLocation().getY(),
                 restaurant.getRatingAverage(),
                 restaurant.getTotalViewCount()
         );

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
@@ -1,0 +1,20 @@
+package com.pickmylunch.api.domain.restaurant.dto.response;
+
+import com.pickmylunch.common.entity.Restaurant;
+import com.pickmylunch.common.entity.enums.Category;
+
+public record RestaurantResponseDto(
+        String id,
+        String restaurantName,
+        Category category,
+        double ratingAverage) {
+
+    public static RestaurantResponseDto of(Restaurant restaurant) {
+        return new RestaurantResponseDto(
+                restaurant.getId(),
+                restaurant.getRestaurantName(),
+                restaurant.getCategory(),
+                restaurant.getRatingAverage()
+        );
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
@@ -7,6 +7,8 @@ public record RestaurantResponseDto(
         String id,
         String restaurantName,
         Category category,
+        double lon,
+        double lat,
         double ratingAverage) {
 
     public static RestaurantResponseDto of(Restaurant restaurant) {
@@ -14,6 +16,8 @@ public record RestaurantResponseDto(
                 restaurant.getId(),
                 restaurant.getRestaurantName(),
                 restaurant.getCategory(),
+                restaurant.getLocation().getX(),
+                restaurant.getLocation().getY(),
                 restaurant.getRatingAverage()
         );
     }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/dto/response/RestaurantResponseDto.java
@@ -7,18 +7,24 @@ public record RestaurantResponseDto(
         String id,
         String restaurantName,
         Category category,
+        String jibunAddress,
+        String doroAddress,
         double lon,
         double lat,
-        double ratingAverage) {
+        double ratingAverage,
+        String restaurantTel) {
 
     public static RestaurantResponseDto of(Restaurant restaurant) {
         return new RestaurantResponseDto(
                 restaurant.getId(),
                 restaurant.getRestaurantName(),
                 restaurant.getCategory(),
+                restaurant.getJibunDetailAddress(),
+                restaurant.getDoroDetailAddress(),
                 restaurant.getLocation().getX(),
                 restaurant.getLocation().getY(),
-                restaurant.getRatingAverage()
+                restaurant.getRatingAverage(),
+                restaurant.getRestaurantTel()
         );
     }
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
@@ -2,6 +2,16 @@ package com.pickmylunch.api.domain.restaurant.repository;
 
 import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, String>, RestaurantRepositoryCustom {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Restaurant r SET r.totalViewCount = r.totalViewCount + :viewCount WHERE r.id = :restaurantId")
+    void incrementTotalViewCount(@Param("restaurantId") String restaurantId, @Param("viewCount") Long viewCount);
+
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
@@ -1,11 +1,16 @@
 package com.pickmylunch.api.domain.restaurant.repository;
 
 import com.pickmylunch.common.entity.Restaurant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+import org.locationtech.jts.geom.Point;
+
+import java.util.*;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, String>, RestaurantRepositoryCustom {
 
@@ -13,5 +18,33 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, String>,
     @Transactional
     @Query("UPDATE Restaurant r SET r.totalViewCount = r.totalViewCount + :viewCount WHERE r.id = :restaurantId")
     void incrementTotalViewCount(@Param("restaurantId") String restaurantId, @Param("viewCount") Long viewCount);
+
+    // 평점 높은 순 정렬
+    @Query("SELECT r FROM Restaurant r " +
+            "WHERE ST_Distance(r.location, :location) <= :range " +
+            "ORDER BY r.ratingAverage DESC")
+    Page<Restaurant> findRestaurantsWithinRangeByRating(
+            @Param("location") Point location,
+            @Param("range") double range,
+            Pageable pageable);
+
+    // 거리 가까운 순 정렬
+    @Query("SELECT r FROM Restaurant r " +
+            "WHERE ST_Distance(r.location, :location) <= :range " +
+            "ORDER BY ST_Distance(r.location, :location) ASC")
+    Page<Restaurant> findRestaurantsWithinRangeByDistance(
+            @Param("location") Point location,
+            @Param("range") double range,
+            Pageable pageable);
+
+    // 추천 식당 (랜덤)
+    @Query("SELECT r FROM Restaurant r " +
+            "WHERE ST_Distance(r.location, :memberLocation) <= 1000 " +
+            "AND r.ratingAverage > (" +
+            "    SELECT AVG(r2.ratingAverage) FROM Restaurant r2 " +
+            "    WHERE ST_Distance(r2.location, :memberLocation) <= 1000" +
+            ") " +
+            "ORDER BY function('RANDOM')")
+    Optional<Restaurant> findRecommendedRestaurantForMember(Point memberLocation);
 
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
@@ -3,5 +3,5 @@ package com.pickmylunch.api.domain.restaurant.repository;
 import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long>, RestaurantRepositoryCustom {
+public interface RestaurantRepository extends JpaRepository<Restaurant, String>, RestaurantRepositoryCustom {
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.pickmylunch.api.domain.restaurant.repository;
+
+import com.pickmylunch.common.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long>, RestaurantRepositoryCustom {
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.domain.*;
 
 public interface RestaurantRepositoryCustom {
-    Page<Restaurant> findAllWithPagination(Pageable pageable);
+    Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu);
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -2,16 +2,7 @@ package com.pickmylunch.api.domain.restaurant.repository;
 
 import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.domain.*;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface RestaurantRepositoryCustom {
     Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu);
-
-    @Modifying
-    @Transactional
-    @Query("UPDATE Restaurant r SET r.totalViewCount = r.totalViewCount + :viewCount WHERE r.id = :restaurantId")
-    void incrementTotalViewCount(@Param("restaurantId") String restaurantId, @Param("viewCount") Long viewCount);
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.pickmylunch.api.domain.restaurant.repository;
+
+import com.pickmylunch.common.entity.Restaurant;
+import org.springframework.data.domain.*;
+
+public interface RestaurantRepositoryCustom {
+    Page<Restaurant> findAllWithPagination(Pageable pageable);
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -2,7 +2,16 @@ package com.pickmylunch.api.domain.restaurant.repository;
 
 import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RestaurantRepositoryCustom {
     Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Restaurant r SET r.totalViewCount = r.totalViewCount + :viewCount WHERE r.id = :restaurantId")
+    void incrementTotalViewCount(@Param("restaurantId") String restaurantId, @Param("viewCount") Long viewCount);
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.pickmylunch.common.entity.Restaurant;
 import org.springframework.data.domain.*;
 
 public interface RestaurantRepositoryCustom {
-    Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu);
+    Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu, String sort, boolean ascending);
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.pickmylunch.api.domain.restaurant.repository;
 
 import com.pickmylunch.common.entity.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -14,11 +15,15 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Restaurant> findAllWithPagination(Pageable pageable) {
-        var query = createQueryWithPagination(pageable);
+    public Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu) {
+        BooleanExpression predicate  = condSigungu(sigungu);
+        var query = createQueryWithPagination(pageable, predicate);
         long total = countTotal();
-
         return new PageImpl<>(query.fetch(), pageable, total);
+    }
+
+    private BooleanExpression condSigungu(String sigungu) {
+        return sigungu == null ? null : restaurant.sigungu.eq(sigungu);
     }
 
     private long countTotal() {
@@ -28,11 +33,12 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
                 .fetchCount();
     }
 
-    private JPAQuery<Restaurant> createQueryWithPagination(Pageable pageable) {
+    private JPAQuery<Restaurant> createQueryWithPagination(Pageable pageable, BooleanExpression predicate) {
         return queryFactory.selectFrom(restaurant)
-                .where(restaurant.id.isNotNull())
+                .where(predicate)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(restaurant.restaurantName.asc());
+                .orderBy(restaurant.totalViewCount.desc());
     }
+
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.pickmylunch.api.domain.restaurant.repository;
+
+import com.pickmylunch.common.entity.*;
+import com.querydsl.jpa.impl.JPAQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static com.pickmylunch.common.entity.QRestaurant.restaurant;
+
+@RequiredArgsConstructor
+public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Restaurant> findAllWithPagination(Pageable pageable) {
+        var query = createQueryWithPagination(pageable);
+        long total = countTotal();
+
+        return new PageImpl<>(query.fetch(), pageable, total);
+    }
+
+    private long countTotal() {
+        return queryFactory
+                .selectFrom(restaurant)
+                .where(restaurant.id.isNotNull())
+                .fetchCount();
+    }
+
+    private JPAQuery<Restaurant> createQueryWithPagination(Pageable pageable) {
+        return queryFactory.selectFrom(restaurant)
+                .where(restaurant.id.isNotNull())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(restaurant.restaurantName.asc());
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.pickmylunch.api.domain.restaurant.repository;
 
-import com.pickmylunch.common.entity.*;
+import com.pickmylunch.common.entity.Restaurant;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
-import com.querydsl.jpa.impl.JPAQueryFactory;
+
 
 import static com.pickmylunch.common.entity.QRestaurant.restaurant;
 
@@ -15,30 +17,40 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu) {
-        BooleanExpression predicate  = condSigungu(sigungu);
-        var query = createQueryWithPagination(pageable, predicate);
-        long total = countTotal();
+    public Page<Restaurant> findRestaurantsBySigungu(Pageable pageable, String sigungu, String sort, boolean ascending) {
+        BooleanExpression predicate = condSigungu(sigungu);
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sort, ascending);
+        var query = createQueryWithPagination(pageable, predicate, orderSpecifier);
+        long total = countTotal(predicate);
         return new PageImpl<>(query.fetch(), pageable, total);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sort, boolean ascending) {
+        if ("rating".equalsIgnoreCase(sort)) {
+            return ascending ? restaurant.ratingAverage.asc() : restaurant.ratingAverage.desc();
+        } else if ("viewCount".equalsIgnoreCase(sort)) {
+            return ascending ? restaurant.totalViewCount.asc() : restaurant.totalViewCount.desc();
+        } else {
+            return restaurant.id.asc();
+        }
     }
 
     private BooleanExpression condSigungu(String sigungu) {
         return sigungu == null ? null : restaurant.sigungu.eq(sigungu);
     }
 
-    private long countTotal() {
+    private long countTotal(BooleanExpression predicate) {
         return queryFactory
                 .selectFrom(restaurant)
-                .where(restaurant.id.isNotNull())
+                .where(predicate)
                 .fetchCount();
     }
 
-    private JPAQuery<Restaurant> createQueryWithPagination(Pageable pageable, BooleanExpression predicate) {
+    private JPAQuery<Restaurant> createQueryWithPagination(Pageable pageable, BooleanExpression predicate, OrderSpecifier<?> orderSpecifier) {
         return queryFactory.selectFrom(restaurant)
                 .where(predicate)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(restaurant.totalViewCount.desc());
+                .orderBy(orderSpecifier);
     }
-
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -22,14 +22,6 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
         return new PageImpl<>(query.fetch(), pageable, total);
     }
 
-    @Override
-    public void incrementTotalViewCount(String restaurantId, Long viewCount) {
-        queryFactory.update(restaurant)
-                .set(restaurant.totalViewCount, restaurant.totalViewCount.add(viewCount))
-                .where(restaurant.id.eq(restaurantId))
-                .execute();
-    }
-
     private BooleanExpression condSigungu(String sigungu) {
         return sigungu == null ? null : restaurant.sigungu.eq(sigungu);
     }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -22,6 +22,14 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
         return new PageImpl<>(query.fetch(), pageable, total);
     }
 
+    @Override
+    public void incrementTotalViewCount(String restaurantId, Long viewCount) {
+        queryFactory.update(restaurant)
+                .set(restaurant.totalViewCount, restaurant.totalViewCount.add(viewCount))
+                .where(restaurant.id.eq(restaurantId))
+                .execute();
+    }
+
     private BooleanExpression condSigungu(String sigungu) {
         return sigungu == null ? null : restaurant.sigungu.eq(sigungu);
     }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/scheduler/ViewCountSyncService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/scheduler/ViewCountSyncService.java
@@ -1,0 +1,34 @@
+package com.pickmylunch.api.domain.restaurant.scheduler;
+
+import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
+import com.pickmylunch.api.global.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ViewCountSyncService {
+
+    private final RedisRepository redis;
+    private final RestaurantRepository restaurantRepository;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void syncAllViewCountsToDb() {
+        Set<String> keys = redis.getAllRestaurantViewKeys();
+        for (String key : keys) {
+            String restaurantId = key.split(":")[1];
+            Long viewCount = redis.getViewCount(restaurantId);
+
+            if (viewCount > 0) {
+                restaurantRepository.incrementTotalViewCount(restaurantId, viewCount);
+
+                redis.resetViewCount(restaurantId);
+            }
+        }
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/LocationService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/LocationService.java
@@ -1,0 +1,43 @@
+package com.pickmylunch.api.domain.restaurant.service;
+
+import com.pickmylunch.api.domain.restaurant.dto.response.*;
+import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
+import com.pickmylunch.api.global.exception.BusinessLogicException;
+import com.pickmylunch.api.global.exception.code.RestaurantExceptionCode;
+import com.pickmylunch.common.entity.*;
+import com.pickmylunch.common.util.GeometryUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LocationService {
+    private static final String RESTAURANT_SORT_OPTION_RATING = "rating";
+    private static final String RESTAURANT_SORT_OPTION_DISTANCE = "distance";
+
+    private final GeometryUtil geometryUtil;
+    private final RestaurantRepository restaurantRepository;
+
+    public Page<RestaurantResponseDto> getRestaurantsWithinRange(double lat, double lon, double range, String sort, int page, int size) {
+        Point location = geometryUtil.createPoint(lon, lat);
+        double distanceInMeters = range * 1000;
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Restaurant> restaurantPage;
+
+        if (RESTAURANT_SORT_OPTION_RATING.equalsIgnoreCase(sort)) {
+            restaurantPage = restaurantRepository.findRestaurantsWithinRangeByRating(location, distanceInMeters, pageable);
+        } else if (RESTAURANT_SORT_OPTION_DISTANCE.equalsIgnoreCase(sort)) {
+            restaurantPage = restaurantRepository.findRestaurantsWithinRangeByDistance(location, distanceInMeters, pageable);
+        } else {
+            throw new BusinessLogicException(RestaurantExceptionCode.INVALID_SORT_TYPE);
+        }
+        return restaurantPage.map(RestaurantResponseDto::of);
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
@@ -30,8 +30,8 @@ public class RestaurantService {
         return RestaurantDetailResponseDto.of(restaurant);
     }
 
-    public Page<RestaurantResponseDto> getRestaurantsBySigungu(Pageable pageable, String sigungu) {
-        return restaurantRepository.findRestaurantsBySigungu(pageable, sigungu)
+    public Page<RestaurantResponseDto> getRestaurantsBySigungu(Pageable pageable, String sigungu, String sort, boolean ascending) {
+        return restaurantRepository.findRestaurantsBySigungu(pageable, sigungu, sort, ascending)
                 .map(RestaurantResponseDto::of);
     }
 

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
@@ -1,7 +1,11 @@
 package com.pickmylunch.api.domain.restaurant.service;
 
+import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantDetailResponseDto;
 import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
 import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
+import com.pickmylunch.api.global.exception.BusinessLogicException;
+import com.pickmylunch.api.global.exception.code.RestaurantExceptionCode;
+import com.pickmylunch.common.entity.Restaurant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,5 +23,15 @@ public class RestaurantService {
     public Page<RestaurantResponseDto> getAllRestaurants(Pageable pageable) {
         return restaurantRepository.findAll(pageable)
                 .map(RestaurantResponseDto::of);
+    }
+
+    @Transactional(readOnly = true)
+    public RestaurantDetailResponseDto getRestaurantById(String id) {
+        Restaurant restaurant = findById(id);
+        return RestaurantDetailResponseDto.of(restaurant);
+    }
+
+    private Restaurant findById(String id) {
+        return restaurantRepository.findById(id).orElseThrow(() -> new BusinessLogicException(RestaurantExceptionCode.RESTAURANT_NOT_FOUND));
     }
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
@@ -1,0 +1,23 @@
+package com.pickmylunch.api.domain.restaurant.service;
+
+import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+
+    @Transactional(readOnly = true)
+    public Page<RestaurantResponseDto> getAllRestaurants(Pageable pageable) {
+        return restaurantRepository.findAll(pageable)
+                .map(RestaurantResponseDto::of);
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
@@ -4,6 +4,7 @@ import com.pickmylunch.api.domain.restaurant.dto.response.*;
 import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
 import com.pickmylunch.api.global.exception.BusinessLogicException;
 import com.pickmylunch.api.global.exception.code.RestaurantExceptionCode;
+import com.pickmylunch.api.global.redis.RedisRepository;
 import com.pickmylunch.common.entity.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
+    private final RedisRepository redis;
 
     public Page<RestaurantResponseDto> getAllRestaurants(Pageable pageable) {
         return restaurantRepository.findAll(pageable)
@@ -24,6 +26,7 @@ public class RestaurantService {
 
     public RestaurantDetailResponseDto getRestaurantById(String id) {
         Restaurant restaurant = findById(id);
+        incrementViewCount(id);
         return RestaurantDetailResponseDto.of(restaurant);
     }
 
@@ -34,6 +37,10 @@ public class RestaurantService {
 
     private Restaurant findById(String id) {
         return restaurantRepository.findById(id).orElseThrow(() -> new BusinessLogicException(RestaurantExceptionCode.RESTAURANT_NOT_FOUND));
+    }
+
+    private void incrementViewCount(String id) {
+        redis.incrementViewCount(id);
     }
 
 }

--- a/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
+++ b/api-server/src/main/java/com/pickmylunch/api/domain/restaurant/service/RestaurantService.java
@@ -1,37 +1,39 @@
 package com.pickmylunch.api.domain.restaurant.service;
 
-import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantDetailResponseDto;
-import com.pickmylunch.api.domain.restaurant.dto.response.RestaurantResponseDto;
+import com.pickmylunch.api.domain.restaurant.dto.response.*;
 import com.pickmylunch.api.domain.restaurant.repository.RestaurantRepository;
 import com.pickmylunch.api.global.exception.BusinessLogicException;
 import com.pickmylunch.api.global.exception.code.RestaurantExceptionCode;
-import com.pickmylunch.common.entity.Restaurant;
+import com.pickmylunch.common.entity.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
 
-    @Transactional(readOnly = true)
     public Page<RestaurantResponseDto> getAllRestaurants(Pageable pageable) {
         return restaurantRepository.findAll(pageable)
                 .map(RestaurantResponseDto::of);
     }
 
-    @Transactional(readOnly = true)
     public RestaurantDetailResponseDto getRestaurantById(String id) {
         Restaurant restaurant = findById(id);
         return RestaurantDetailResponseDto.of(restaurant);
     }
 
+    public Page<RestaurantResponseDto> getRestaurantsBySigungu(Pageable pageable, String sigungu) {
+        return restaurantRepository.findRestaurantsBySigungu(pageable, sigungu)
+                .map(RestaurantResponseDto::of);
+    }
+
     private Restaurant findById(String id) {
         return restaurantRepository.findById(id).orElseThrow(() -> new BusinessLogicException(RestaurantExceptionCode.RESTAURANT_NOT_FOUND));
     }
+
 }

--- a/api-server/src/main/java/com/pickmylunch/api/global/exception/code/RestaurantExceptionCode.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/exception/code/RestaurantExceptionCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum RestaurantExceptionCode implements ExceptionCode {
-    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 맛집입니다.");
+    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 맛집입니다."),
+    INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 정렬 타입입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/api-server/src/main/java/com/pickmylunch/api/global/exception/code/RestaurantExceptionCode.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/exception/code/RestaurantExceptionCode.java
@@ -1,0 +1,25 @@
+package com.pickmylunch.api.global.exception.code;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RestaurantExceptionCode implements ExceptionCode {
+    RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 맛집입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/global/redis/RedisKeyGenerator.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/redis/RedisKeyGenerator.java
@@ -1,0 +1,19 @@
+package com.pickmylunch.api.global.redis;
+
+public class RedisKeyGenerator {
+    private static final String RESTAURANT_VIEW_KEY_PATTERN = "restaurant:%s:v";
+    private static final String RESTAURANT_VIEW_KEY_PATTERN_ALL = "restaurant:*:v";
+    private static final String MEMBER_LOCATION_KEY_PATTERN = "member_location:%d";
+
+    public static String generateRestaurantViewKey(String restaurantId) {
+        return String.format(RESTAURANT_VIEW_KEY_PATTERN, restaurantId);
+    }
+
+    public static String generateRestaurantViewKeyPattern() {
+        return RESTAURANT_VIEW_KEY_PATTERN_ALL;
+    }
+
+    public static String generateRealTimeLocationKey(Long memberId) {
+        return String.format(MEMBER_LOCATION_KEY_PATTERN, memberId);
+    }
+}

--- a/api-server/src/main/java/com/pickmylunch/api/global/redis/RedisRepository.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/redis/RedisRepository.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Repository
@@ -33,14 +34,14 @@ public class RedisRepository {
     }
 
     public void saveRealTimeLocation(Long memberId, double lon, double lat) {
-        String key = generateRealTimeLocationKey(memberId);
+        String key = RedisKeyGenerator.generateRealTimeLocationKey(memberId);
         GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
         geoOps.add(key, new Point(round(lon, 6), round(lat, 6)), String.valueOf(memberId));
         redisTemplate.expire(key, 15, TimeUnit.MINUTES);
     }
 
     public Point getRealTimeLocation(Long memberId) {
-        String key = generateRealTimeLocationKey(memberId);
+        String key = RedisKeyGenerator.generateRealTimeLocationKey(memberId);
         GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
         List<Point> positions = geoOps.position(key, String.valueOf(memberId));
         Point point = getFirstPositionOrThrow(positions);
@@ -60,7 +61,23 @@ public class RedisRepository {
         return bd.doubleValue();
     }
 
-    public String generateRealTimeLocationKey(Long memberId) {
-        return "member_location:" + memberId;
+    public void incrementViewCount(String restaurantId) {
+        String key = RedisKeyGenerator.generateRestaurantViewKey(restaurantId);
+        redisTemplate.opsForValue().increment(key, 1);
+    }
+
+    public Long getViewCount(String restaurantId) {
+        String key = RedisKeyGenerator.generateRestaurantViewKey(restaurantId);
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : 0L;
+    }
+
+    public Set<String> getAllRestaurantViewKeys() {
+        return redisTemplate.keys(RedisKeyGenerator.generateRestaurantViewKeyPattern());
+    }
+
+    public void resetViewCount(String restaurantId) {
+        String key = RedisKeyGenerator.generateRestaurantViewKey(restaurantId);
+        redisTemplate.opsForValue().set(key, "0");
     }
 }

--- a/api-server/src/main/java/com/pickmylunch/api/global/security/config/SecurityConfig.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/security/config/SecurityConfig.java
@@ -43,8 +43,9 @@ public class SecurityConfig {
                                         .requestMatchers("/api/members/exists/**").permitAll()
                                         .requestMatchers("/api/members").permitAll()
                                         .requestMatchers("/api/login", "/api/auth/reissue").permitAll()
-                                        .requestMatchers("/api/region/**").permitAll()
                                         .requestMatchers("/api/members/me/**", "/api/members/me/alerts/recommendation").authenticated()
+                                        .requestMatchers("/api/restaurant/**").permitAll()
+                                        .requestMatchers("/api/region/search").permitAll()
                                         .requestMatchers("/api/members/locations/**").authenticated()
                                         .anyRequest().authenticated()
                 )
@@ -75,8 +76,8 @@ public class SecurityConfig {
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Location", "Refresh"));
-        configuration.setExposedHeaders(List.of("Authorization", "Refresh"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Location", "refresh-token"));
+        configuration.setExposedHeaders(List.of("Authorization", "refresh-token"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/api-server/src/main/java/com/pickmylunch/api/global/security/config/SecurityConfig.java
+++ b/api-server/src/main/java/com/pickmylunch/api/global/security/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                         .requestMatchers("/api/members/me/**", "/api/members/me/alerts/recommendation").authenticated()
                                         .requestMatchers("/api/restaurant/**").permitAll()
                                         .requestMatchers("/api/region/search").permitAll()
+                                        .requestMatchers("/api/restaurants/nearby/**").authenticated()
                                         .requestMatchers("/api/members/locations/**").authenticated()
                                         .anyRequest().authenticated()
                 )

--- a/batch-server/src/main/java/com/pickmylunch/batch/pipeline/service/ApiFetcher.java
+++ b/batch-server/src/main/java/com/pickmylunch/batch/pipeline/service/ApiFetcher.java
@@ -33,7 +33,7 @@ public class ApiFetcher {
     }
 
     private String buildUri(int start, int end) {
-        return MessageFormat.format("{0}/{1}/{2}/{3}/{4}",
+        return String.format("%s/%s/%s/%d/%d",
                 apiProperties.getKey(),
                 apiProperties.getFormatType(),
                 apiProperties.getServiceName(),

--- a/batch-server/src/main/java/com/pickmylunch/batch/pipeline/service/RestaurantProcessor.java
+++ b/batch-server/src/main/java/com/pickmylunch/batch/pipeline/service/RestaurantProcessor.java
@@ -86,10 +86,14 @@ public class RestaurantProcessor {
             return null;
         }
 
-        double longitude = Double.parseDouble(x);
-        double latitude = Double.parseDouble(y);
-
-        return geometryUtil.createPoint(longitude, latitude);
+        try {
+            double longitude = Double.parseDouble(x);
+            double latitude = Double.parseDouble(y);
+            return geometryUtil.createPointFromTM(longitude, latitude);
+        } catch (NumberFormatException e) {
+            log.warn("[warn] 좌표 변환 실패 x: {}, y: {}", x, y);
+            return null;
+        }
     }
 
     public boolean shouldUpdate(RawRestaurant rawRestaurant) {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	// proj4j
+	implementation 'org.locationtech.proj4j:proj4j:1.1.1'
 }
 
 tasks.named('test') {

--- a/common/src/main/java/com/pickmylunch/common/entity/Restaurant.java
+++ b/common/src/main/java/com/pickmylunch/common/entity/Restaurant.java
@@ -36,4 +36,8 @@ public class Restaurant {
     private Point location;
 
     private double ratingAverage;
+
+    @Column(nullable = false)
+    private long totalViewCount;
+
 }

--- a/common/src/main/java/com/pickmylunch/common/util/GeometryUtil.java
+++ b/common/src/main/java/com/pickmylunch/common/util/GeometryUtil.java
@@ -1,19 +1,43 @@
 package com.pickmylunch.common.util;
 
-import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.*;
+import org.locationtech.proj4j.*;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class GeometryUtil {
+
     private final GeometryFactory geometryFactory;
+    private final CoordinateTransform transform;
+
+    public GeometryUtil(GeometryFactory geometryFactory) {
+        this.geometryFactory = geometryFactory;
+
+        // 변환 객체 캐싱
+        CRSFactory crsFactory = new CRSFactory();
+        CoordinateReferenceSystem srcCrs = crsFactory.createFromName("EPSG:5179");
+        CoordinateReferenceSystem dstCrs = crsFactory.createFromName("EPSG:4326");
+        CoordinateTransformFactory transformFactory = new CoordinateTransformFactory();
+        this.transform = transformFactory.createTransform(srcCrs, dstCrs);
+    }
 
     public Point createPoint(final double lon, final double lat) {
         Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
         point.setSRID(4326);
         return point;
+    }
+
+    public Point createPointFromTM(double x, double y) {
+        Coordinate coord = convertTmToWgs84(x, y);
+        Point point = geometryFactory.createPoint(coord);
+        point.setSRID(4326);
+        return point;
+    }
+
+    public Coordinate convertTmToWgs84(double x, double y) {
+        ProjCoordinate src = new ProjCoordinate(x, y);
+        ProjCoordinate dst = new ProjCoordinate();
+        transform.transform(src, dst);
+        return new Coordinate(dst.x, dst.y);
     }
 }


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
- closed #13 
## :writing_hand: Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 맛집 전체 조회
- 맛집 상세 조회
- 맛집 구별 필터링 조회
- 맛집 상세 조회 시, Redis 기반 1시간 단위 조회수 증가 처리
- 일정 주기로 Redis에 누적된 조회수를 DB에 저장 (조회수 영속화)
- 위치 기반 맛집 조회
## :white_check_mark: Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 전체 맛집 목록 조회
![전체 맛집 목록 조회](https://github.com/user-attachments/assets/67445269-d606-4bc4-bca9-3da41c570be5)
- 맛집 상세 조회
![맛집 상세 조회](https://github.com/user-attachments/assets/c05227a9-9714-4c59-aa37-580f622a2d2f)
-맛집 구별 필터링 조회
![시군구 필터 맛집 목록 조회](https://github.com/user-attachments/assets/7d536fbd-8749-4942-816f-16afb714d4e4)
- 위치 기반 맛집 조회
![위치별 범위내 맛집 조회](https://github.com/user-attachments/assets/90e8937e-d87d-4a61-9fd2-c6a9d079a439)